### PR TITLE
Whitelist a Spanish IT blog

### DIFF
--- a/whitelist/wl-custom.txt
+++ b/whitelist/wl-custom.txt
@@ -64,3 +64,4 @@ wp.com
 x.com
 yahoo.com
 zendesk.com
+bandaancha.eu


### PR DESCRIPTION
False positive, it's a technology blog with ISP/law related content.  bandaancha.eu